### PR TITLE
page généraliste pour B2G au lieu de la page wiki

### DIFF
--- a/tabzilla.js
+++ b/tabzilla.js
@@ -413,7 +413,7 @@ Tabzilla.content =
     + '        <ul>'
     + '          <li><a href="https://www.mozilla.org/fr/firefox/fx/">Firefox</a></li>'
     + '          <li><a href="https://www.mozilla.org/fr/thunderbird/">Thunderbird</a></li>'
-    + '          <li><a href="https://wiki.mozilla.org/B2G">Firefox OS</a></li>'
+    + '          <li><a href="https://www.mozilla.org/en-US/b2g/">Firefox OS</a></li>'
     + '          <li><a href="https://addons.mozilla.org/fr/">Extensions</a></li>'
     + '        </ul>'
     + '      </li>'


### PR DESCRIPTION
Il existe une page produit pour B2G qui décrit le projet, @pascalchevrel il serait possible de la traduire en fr ?
